### PR TITLE
8 build a hook for api requests

### DIFF
--- a/public/mockdata_drinks.json
+++ b/public/mockdata_drinks.json
@@ -1,0 +1,74 @@
+{
+	"drinks": [
+		{
+			"id": 1,
+			"name": "Mojito",
+			"description": "Refreshing mint cocktail with rum",
+			"price": 6.99,
+			"imageUrl": null,
+			"available": true,
+			"label": "alcoholic",
+			"availableSizes": ["standard"]
+		},
+		{
+			"id": 2,
+			"name": "Lemonade",
+			"description": "Freshly squeezed lemonade",
+			"price": 3.5,
+			"imageUrl": null,
+			"available": true,
+			"label": null,
+			"availableSizes": ["small", "medium", "large"]
+		},
+		{
+			"id": 3,
+			"name": "Craft Beer",
+			"description": "Locally brewed craft beer",
+			"price": 5.0,
+			"imageUrl": null,
+			"available": false,
+			"label": "alcoholic",
+			"availableSizes": ["standard"]
+		},
+		{
+			"id": 4,
+			"name": "Iced Tea",
+			"description": "Chilled tea with a hint of lemon",
+			"price": 2.99,
+			"imageUrl": null,
+			"available": true,
+			"label": null,
+			"availableSizes": ["medium", "large"]
+		},
+		{
+			"id": 5,
+			"name": "Whiskey Sour",
+			"description": "Whiskey mixed with lemon juice",
+			"price": 7.5,
+			"imageUrl": null,
+			"available": true,
+			"label": "alcoholic",
+			"availableSizes": ["standard"]
+		},
+		{
+			"id": 6,
+			"name": "Mineral Water",
+			"description": "Natural mineral water",
+			"price": 1.99,
+			"imageUrl": null,
+			"available": true,
+			"label": null,
+			"availableSizes": ["small", "standard", "large"]
+		},
+		{
+			"id": 7,
+			"name": "Gin and Tonic",
+			"description": "Gin mixed with tonic water",
+			"price": 6.5,
+			"imageUrl": null,
+			"available": true,
+			"label": "alcoholic",
+			"availableSizes": ["standard"]
+		}
+	]
+}

--- a/public/mockdata_food.json
+++ b/public/mockdata_food.json
@@ -1,0 +1,58 @@
+{
+	"food": [
+		{
+			"id": 1,
+			"name": "Cheeseburger",
+			"description": "A juicy cheeseburger with a beef patty, cheese, lettuce, and tomato",
+			"price": 8.99,
+			"imageUrl": null,
+			"available": true,
+			"label": null
+		},
+		{
+			"id": 2,
+			"name": "Veggie Pizza",
+			"description": "Delicious pizza topped with a variety of vegetables",
+			"price": 10.5,
+			"imageUrl": null,
+			"available": true,
+			"label": "veggie"
+		},
+		{
+			"id": 3,
+			"name": "Chicken Wings",
+			"description": "Spicy and savory chicken wings served with a side of sauce",
+			"price": 7.99,
+			"imageUrl": null,
+			"available": false,
+			"label": null
+		},
+		{
+			"id": 4,
+			"name": "Garden Salad",
+			"description": "Fresh garden salad with a mix of greens, tomatoes, and cucumbers",
+			"price": 6.99,
+			"imageUrl": null,
+			"available": true,
+			"label": "vegan"
+		},
+		{
+			"id": 5,
+			"name": "Steak",
+			"description": "Grilled steak cooked to your liking, served with vegetables",
+			"price": 15.99,
+			"imageUrl": null,
+			"available": true,
+			"label": null
+		},
+		{
+			"id": 6,
+			"name": "Grilled Cheese Sandwich",
+			"description": "Classic grilled cheese sandwich with melted cheese on toasted bread",
+			"price": 5.99,
+			"imageUrl": null,
+			"available": true,
+			"label": null
+		}
+	]
+}

--- a/src/app/components/DigitalMenu.tsx
+++ b/src/app/components/DigitalMenu.tsx
@@ -2,50 +2,23 @@ import React, { useState, useEffect } from "react";
 import { TMenuItemFood, TMenuItemDrink } from "../../interfaces/menuItem";
 import { drinks as mockDrinks, food as mockFood } from "../lib/mockdata";
 import { MenuItemFood } from "./MenuItemFood";
+import { useFetchData } from "../hooks/useFetchData";
 
-type fetchStatus = "idle" | "loading" | "error" | "success";
+type TFoodData = {
+	food: TMenuItemFood[];
+};
 
 export const DigitalMenu: React.FC = () => {
 	const [food, setFood] = useState<TMenuItemFood[]>([]);
 	const [drinks, setDrinks] = useState<TMenuItemDrink[]>([]);
-	const [status, setStatus] = useState<fetchStatus>("idle");
+
+	const { data, status, errorMessage } = useFetchData<TFoodData>(
+		"/mockdata_food.json"
+	);
 
 	useEffect(() => {
-		const fetchDrinks = async (): Promise<TMenuItemDrink[]> => {
-			setStatus("loading");
-			// we will move this function to a custom hook later
-			return new Promise((resolve) => {
-				setTimeout(() => {
-					setStatus("success");
-					return resolve(mockDrinks as unknown as TMenuItemDrink[]);
-				}, 2000);
-			});
-		};
-
-		const fetchFood = async (): Promise<TMenuItemFood[]> => {
-			setStatus("loading");
-			// we will move this function to a custom hook later
-			return new Promise((resolve) => {
-				setTimeout(() => {
-					setStatus("success");
-					return resolve(mockFood as unknown as TMenuItemFood[]);
-				}, 2000);
-			});
-		};
-
-		fetchDrinks()
-			.then((items) => {
-				console.log(items);
-				setDrinks(items);
-			})
-			.catch((err) => setStatus("error"));
-		fetchFood()
-			.then((items) => {
-				console.log(items);
-				setFood(items);
-			})
-			.catch((err) => setStatus("error"));
-	}, []);
+		data?.food && setFood(data.food);
+	}, [data]);
 
 	return (
 		<div className="digitalMenu">

--- a/src/app/hooks/useFetchData.tsx
+++ b/src/app/hooks/useFetchData.tsx
@@ -14,14 +14,15 @@ export const useFetchData = <T,>(url: string): TResponse<T> => {
 
 	useEffect(() => {
 		const fetchData = async () => {
+			setStatus("loading");
 			try {
-				setStatus("loading");
-				fetch(url)
-					.then((res) => res.json())
-					.then((data) => {
-						setData(data);
-						setStatus("success");
-					});
+				const response = await fetch(url);
+				if (!response.ok) {
+					throw new Error("Something went wrong");
+				}
+				const jsonData = await response.json();
+				setData(jsonData);
+				setStatus("success");
 			} catch (error) {
 				setStatus("error");
 				setErrorMessage((error as Error).message);

--- a/src/app/hooks/useFetchData.tsx
+++ b/src/app/hooks/useFetchData.tsx
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+
+type TRequestStatus = "idle" | "loading" | "success" | "error";
+type TResponse<T> = {
+	data: T | null;
+	status: TRequestStatus;
+	errorMessage?: string | null;
+};
+
+export const useFetchData = <T,>(url: string): TResponse<T> => {
+	const [data, setData] = useState<T | null>(null);
+	const [status, setStatus] = useState<TRequestStatus>("idle");
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				setStatus("loading");
+				fetch(url)
+					.then((res) => res.json())
+					.then((data) => {
+						setData(data);
+						setStatus("success");
+					});
+			} catch (error) {
+				setStatus("error");
+				setErrorMessage((error as Error).message);
+			}
+		};
+
+		fetchData();
+	}, []);
+
+	return { data, status, errorMessage };
+};


### PR DESCRIPTION
I created a custom hook inside the /hooks folder, called useFetchData.

The hook should be reusable for api calls, being type generically (is that a word?) 

It receives the url to fetch from as a prop and returns an object { data, status, errorMessage } after the request is done.

I used { data, , isLoading, error, idle } at first but then decided to use 'status' to make it more concies. Still had to set a property for an error message though. What do you think about that? 

The generic types should ensure that we get what we expect. 

I testet it manually with some mockdata which I exposed in the /public folder. It works (on my machine). 